### PR TITLE
[L1-114] Update component short descriptions

### DIFF
--- a/components/ex-kafka/component_config/component_short_description.md
+++ b/components/ex-kafka/component_config/component_short_description.md
@@ -1,1 +1,1 @@
-Apache Kafka is an open-source log-based event streaming platform.
+Consumes messages from Apache Kafka topics.

--- a/components/wr-kafka/component_config/component_short_description.md
+++ b/components/wr-kafka/component_config/component_short_description.md
@@ -1,1 +1,1 @@
-Apache Kafka is an open-source log-based event streaming platform.
+Produces messages to an Apache Kafka topic from input table rows.


### PR DESCRIPTION
Batch cleanup of component short descriptions (the one-liner in the platform component list) - they described the vendor product instead of what the component does.

Tracked in https://linear.app/keboola/issue/L1-114/make-component-short-descriptions-consistent-support-13792 (SUPPORT-13792). Reviewed and approved by Component Factory.

Changes in this repo:
- `keboola.ex-kafka` -> Consumes messages from Apache Kafka topics.
- `keboola.wr-kafka` -> Produces messages to an Apache Kafka topic from input table rows.

One-line content change to `component_config/component_short_description.md`. Please review wording and merge.